### PR TITLE
Edits for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include jupyter_higlass/static *.*
+recursive-include higlass_jupyter/static *.*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean all
+.PHONY: all build dist install uninstall clean publish-test publish
 
 install:
 	python setup.py jsdeps
@@ -16,3 +16,14 @@ build:
 clean:
 	rm -rf higlass_jupyter/static/
 	rm -rf build
+	rm -rf dist
+
+dist: clean
+	python setup.py sdist bdist_wheel
+
+# pip install --index-url https://test.pypi.org/simple/ higlass_jupyter
+publish-test: dist
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+publish: dist
+	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,17 @@
 
 install:
 	python setup.py jsdeps
-	jupyter nbextension install --py --symlink --sys-prefix jupyter_higlass
-	jupyter nbextension enable --py --sys-prefix jupyter_higlass
+	jupyter nbextension install --py --symlink --sys-prefix higlass_jupyter
+	jupyter nbextension enable --py --sys-prefix higlass_jupyter
 
 uninstall:
-	jupyter nbextension uninstall --py --sys-prefix jupyter_higlass
-	rm -rf jupyter_higlass/static/
+	jupyter nbextension uninstall --py --sys-prefix higlass_jupyter
+	rm -rf higlass_jupyter/static/
 	rm -rf build
 
 build:
 	python setup.py jsdeps
 
 clean:
-	rm -rf jupyter_higlass/static/
+	rm -rf higlass_jupyter/static/
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jupyter-higlass
+higlass-jupyter
 ===============================
 
 HiGlass Widget Extension for your Jupyter Notebook
@@ -19,13 +19,13 @@ Optionally, the following [Unofficial Community Extensions](http://jupyter-contr
 Development
 -----------
 
-1\. Install this repo as a Python package. With pip's `-e` option, the package is installed in developer (a.k.a. editable) mode, such that the `jupyter_higlass` package is linked Python's `site-packages` directory rather than copied there. This way the package can be edited directly in the repo with no need for build or re-installing.
+1\. Install this repo as a Python package. With pip's `-e` option, the package is installed in developer (a.k.a. editable) mode, such that the `higlass_jupyter` package is linked Python's `site-packages` directory rather than copied there. This way the package can be edited directly in the repo with no need for build or re-installing.
 
     $ git clone https://github.com/pkerpedjiev/higlass-jupyter.git
-    $ cd jupyter-higlass
+    $ cd higlass-jupyter
     $ pip install -e .
 
-2\. Compile and install the Javascript notebook extension (requires npm). With the `--symlink` option, the compiled Javascript in `jupyter_higlass/static` is linked to the extension registry rather than copied. This way both the Python package and front-end assets are linked from the repo.
+2\. Compile and install the Javascript notebook extension (requires npm). With the `--symlink` option, the compiled Javascript in `higlass_jupyter/static` is linked to the extension registry rather than copied. This way both the Python package and front-end assets are linked from the repo.
 
 	$ python setup.py jsdeps
     $ jupyter nbextension install --py --sys-prefix --symlink higlass_jupyter
@@ -80,8 +80,8 @@ minimal_config = {
 }
 
 import json
-import jupyter_higlass
-jupyter_higlass.HiGlassDisplay(viewconf=json.dumps(minimal_config))
+import higlass_jupyter
+higlass_jupyter.HiGlassDisplay(viewconf=json.dumps(minimal_config))
 ```
 
 
@@ -90,7 +90,7 @@ Uninstall
 
 To uninstall both the Python package and Javascript extension:
 
-	$ pip uninstall jupyter_higlass
+	$ pip uninstall higlass_jupyter
 	$ jupyter nbextension uninstall --py --sys-prefix higlass_jupyter
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-- To release a new version of jupyter_higlass on PyPI:
+- To release a new version of higlass_jupyter on PyPI:
 
 Update _version.py (set release version, remove 'dev')
 git add the _version.py file and git commit
@@ -10,7 +10,7 @@ git add and git commit
 git push
 git push --tags
 
-- To release a new version of jupyter_higlass on NPM:
+- To release a new version of higlass_jupyter on NPM:
 
 ```
 # clean out the `dist` and `node_modules` directories

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,8 @@ setup_args = {
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 }
 


### PR DESCRIPTION
* Converted remaining instances of old jupyter_higlass name, including MANIFEST.in
* Added to Makefile commands to generate sdists and universal wheels and to publish using twine

Both the sdist and wheel should ship with bundled web assets and no js source, but we still need to test that installation works.
